### PR TITLE
Updated to the stable RangeInclusive API of Rust 1.27+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "range-set"
-version = "0.0.4"
-authors = ["Shane Pearman <spearman@github.com>"]
+version = "0.0.5"
+authors = ["Shane Pearman <spearman@github.com>", "Alex Moon <alex.r.moon@gmail.com>"]
 license = "Apache-2.0"
 description = "Smallvec-backed containers of sorted integer ranges"
 repository = "https://github.com/spearman/range-set"

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,4 +1,3 @@
-#![feature(inclusive_range)]
 extern crate range_set;
 
 use range_set::RangeSet;


### PR DESCRIPTION
Rust 1.27 made the start and end fields of RangeInclusive private and provided start() and end() methods instead. This change updates range-set to use the new API so it will build on current stable Rust.